### PR TITLE
Fixed ~ expansion bug

### DIFF
--- a/setoolkit
+++ b/setoolkit
@@ -54,8 +54,9 @@ if operating_system == "posix":
         # create the set variables
         os.makedirs(setdir)
         # if for some reason it failed to pull the path
-        if not os.path.isdir("~/.set/"):
-            os.makedirs("~/.set/")
+        userdir = os.path.join(os.path.expanduser('~'), '.set')
+        if not os.path.isdir(userdir):
+            os.makedirs(userdir)
 
 
 if not os.path.isdir(setdir + "/reports/"):


### PR DESCRIPTION
In Mac OS X '~' will not expand to the user directory. Instead, a directory by the name of '~' will be created. This patch fixes this issue.
