### PR TITLE
Fix copying entire directory when using apache and track names

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -453,6 +453,9 @@ def run():
             filewrite.close()
             os.remove(setdir + "/web_clone/index.html")
             shutil.copyfile(setdir + "/web_clone/index.2", setdir + "/web_clone/index.html")
+            # copy the entire web_clone directory.  
+            # Without this only index.php|html are copied even though the user may have chosen to import the entire directory in the set module.
+            copyfolder(setdir + "/web_clone", apache_dir)
         if os.path.isfile("%s/index.html" % (apache_dir)):
             os.remove("%s/index.html" % (apache_dir))
         if track_email == False:


### PR DESCRIPTION
If the user decides to clone the entire directory when asked during the set.py module it gets copied successfully to ~/.set/web_clone, however, if apache is in use the entire directory is not copied to the apache_dir.  Only the index file was being copied.  This change does a full folder copy of web_clone to apache_dir and then copies over the modified index.html or php file.
