### PR TITLE
Correct binary filename for set updater in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if platform.system() == "Linux":
         subprocess.Popen("git clone https://github.com/trustedsec/social-engineer-toolkit /usr/share/setoolkit", shell=True).wait()
         print "[*] Installing setoolkit installer to /usr/bin/setoolkit..."
         subprocess.Popen("cp /usr/share/setoolkit/setoolkit /usr/bin", shell=True).wait()
-        subprocess.Popen("cp /usr/share/setoolkit/set-update /usr/bin/", shell=True).wait()
+        subprocess.Popen("cp /usr/share/setoolkit/seupdate /usr/bin/", shell=True).wait()
         subprocess.Popen("chmod +x /usr/bin/setoolkit", shell=True).wait()
         print "[*] Note you will manually need to install Core Security 'Impacket'"
         print "[*] Download link: http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=tool&name=Impacket"


### PR DESCRIPTION
setup.py tries to copy /usr/share/setoolkit/set-update to /usr/bin, however this file does not exist.

The correct filename is /usr/share/setoolkit/seupdate.
