### PR TITLE
Check sys platform before performing chown on site cloner txt file

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -444,7 +444,12 @@ def run():
         filewrite = file("%s/harvester_%s.txt" % (logpath,now), "w")
         filewrite.write("")
         filewrite.close()
-        subprocess.Popen("chown www-data:www-data '%s/harvester_%s.txt'" % (logpath,now), shell=True).wait()
+
+        # Check sys platform to perform chown
+        if sys.platform == "darwin":
+            subprocess.Popen("chown _www:_www '%s/harvester_%s.txt'" % (logpath,now), shell=True).wait()
+        else:
+            subprocess.Popen("chown www-data:www-data '%s/harvester_%s.txt'" % (logpath,now), shell=True).wait()
 
         # if we are using webjacking, etc.
         if os.path.isfile(setdir + "/web_clone/index2.html"):


### PR DESCRIPTION
A fix on `Site Cloner` on OS X:

<img width="724" alt="2015-09-27 6 10 19" src="https://cloud.githubusercontent.com/assets/1324420/10122208/0fe0a6a2-6543-11e5-8392-a3f2cb9a2ba4.png">
