### PR TITLE
Wget check clean-up

### DIFF
--- a/src/webattack/web_clone/cloner.py
+++ b/src/webattack/web_clone/cloner.py
@@ -128,19 +128,15 @@ try:
         counter=0
         # try except block in case no internet connection, route to Internet, etc.
         try:
-                # check if we have wget, if we don't then use urllib2
-            wget = 0
-            if os.path.isfile("/usr/local/bin/wget"):
-                wget = 1
-            if os.path.isfile("/usr/bin/wget"):
-                wget = 1
-            if os.path.isfile("/usr/local/wget"):
-                wget = 1
+            # check if we have wget, if we don't then use urllib2
+            # wget is called, but output is sent to devnull to hide "wget: missing URL" error
+            DNULL = open(os.devnull, 'w')
+            wget = subprocess.Popen('wget', shell=True, stdout=DNULL, stderr=subprocess.STDOUT)
 
             if wget == 1:
                 subprocess.Popen('%s;cd %s/web_clone/;wget --no-check-certificate -O index.html -c -k -U "%s" "%s";' % (proxy_config,setdir,user_agent,url), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
 
-            if wget == 0:
+            else:
                 # if we don't have wget installed we will use python to rip, not as good as wget
                 headers = { 'User-Agent' : user_agent }
                 # read in the websites

--- a/src/webattack/web_clone/cloner.py
+++ b/src/webattack/web_clone/cloner.py
@@ -131,8 +131,7 @@ try:
             # check if we have wget, if we don't then use urllib2
             # wget is called, but output is sent to devnull to hide "wget: missing URL" error
             DNULL = open(os.devnull, 'w')
-            wget = subprocess.Popen('wget', shell=True, stdout=DNULL, stderr=subprocess.STDOUT)
-
+            wget = subprocess.call('wget', shell=True, stdout=DNULL, stderr=subprocess.STDOUT)
             if wget == 1:
                 subprocess.Popen('%s;cd %s/web_clone/;wget --no-check-certificate -O index.html -c -k -U "%s" "%s";' % (proxy_config,setdir,user_agent,url), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
 


### PR DESCRIPTION
This is just some clean-up that should also help add support for wget when it isn't in one of the defined folders (like on a Windows machine) and make the process more efficient. Instead of checking for wget in various locations, subprocess is used to call it. If wget works, subprocess returns 1. The additional arguments used with subprocess.call hide the wget error message and help info (i.e. "wget: missing URL ...").

Also, I'm supposed to mention Charles Yost told me to submit this when we spoke at CodeMash. :)