### PR TITLE
Open relay with blank password broken

### DIFF
--- a/src/phishing/smtp/client/smtp_web.py
+++ b/src/phishing/smtp/client/smtp_web.py
@@ -304,7 +304,8 @@ def mail(to, subject, prioflag1, prioflag2, text):
         if provideruser != "" or pwd != "":
             mailServer.login(provideruser, pwd)
             mailServer.sendmail(from_address, to, io.getvalue())
-
+        else:
+            mailServer.sendmail(from_address, to, io.getvalue())
     except:
         # try logging in with base64 encoding here
         import base64


### PR DESCRIPTION
With sendmail disabled and using an open relay with a blank password the mailServer.sendmail() function is skipped.

email_provider is still initialized as "gmail" even when open relay is selected from the menu.