### PR TITLE
fixing bug with Kali linux bleeding edge

### DIFF
--- a/src/core/setcore.py
+++ b/src/core/setcore.py
@@ -345,7 +345,10 @@ def meta_path():
         if os.path.isfile("/usr/bin/msfconsole"):
             msf_path = ""
             trigger = 1
-
+        #﻿Kali linux bleeding edge should return this in order to work
+        if os.path.isfile("/usr/share/metasploit-framework/msfconsole"):
+            msf_path = "/usr/share/metasploit-framework/"
+            trigger = 1
         # if we are using windows
         if check_os() == "windows":
             print_warning(


### PR DESCRIPTION
SET won't find metasploit and so won't start attack vector. i.e Teensy attack. This should fix