### PR TITLE
Fix smtp email client

### DIFF
--- a/src/phishing/smtp/client/smtp_client.py
+++ b/src/phishing/smtp/client/smtp_client.py
@@ -10,20 +10,24 @@ import glob
 import random
 import pexpect
 import base64
-import thread
 
-# python 2 to 3 fix
+# python 2 to 3 fixes
+try:
+    import _thread as thread # Py3
+except ImportError:
+    import thread # Py2
 try:
     from cStringIO import StringIO
-except NameError:
+except ImportError:
     from io import StringIO
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEBase import MIMEBase
-from email.MIMEText import MIMEText
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email.mime.text import MIMEText
 from email.header import Header
 from email.generator import Generator
-from email import Charset
-from email import Encoders
+import email.charset as Charset
+import email.encoders as Encoders
 
 # DEFINE SENDMAIL CONFIG
 sendmail = 0


### PR DESCRIPTION
I think that all the code in this repo is supposed to be python 2 and python 3 compatible. These changes make the email client work in python3 (and python 2 if I was reading the docs correctly) I'm somewhat suspicious of those email module imports but who knows!

I believe this will be my last request but It might be worth a sweep through to change the imports (I noticed other files blindly imported thread without a try catch) if someone ever has time.

Thanks for the quick action :+1: 