### PR TITLE
Fix inconsistent use of tabs and space in fasttrack.py

### DIFF
--- a/src/core/fasttrack.py
+++ b/src/core/fasttrack.py
@@ -162,7 +162,7 @@ try:
                         if sql != "":
                             print(sql)
 
-		    if len(sql_servers) > 2:
+                    if len(sql_servers) > 2:
                         print_status("By pressing enter, you will begin the brute force process on all SQL accounts identified in the list above.")
                         test = input("Press {enter} to begin the brute force process.")
                     for servers in sql_servers:


### PR DESCRIPTION
That was making the setoolkit break when selecting Option 2) at the main menu.