### PR TITLE
changed pefile section in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,10 @@ if platform.system() == "Linux":
             subprocess.Popen("pacman -S --noconfirm --needed git python2 "
                              "python2-beautifulsoup3 python2-pexpect python2-crypto", shell=True).wait()
 
-            subprocess.Popen("wget https://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz", shell=True).wait()
-            subprocess.Popen("tar xvfz pefile-1.2.10-139.tar.gz", shell=True).wait()
-            subprocess.Popen("chmod a+x pefile-1.2.10-139/setup.py", shell=True).wait()
-            subprocess.Popen("rm -rf pefile-1.2.10-139*", shell=True).wait()
+            subprocess.Popen("wget https://github.com/erocarrera/pefile/archive/master.zip", shell=True).wait()
+            subprocess.Popen("unzip master.zip", shell=True).wait()
+            subprocess.Popen("chmod a+x pefile-master/setup.py", shell=True).wait()
+            subprocess.Popen("rm -rf pefile-master*", shell=True).wait()
 
         # if dnf.conf is there, we are dealing with a >= fedora 22 - added thanks to whoismath pr
         elif os.path.isfile("/etc/dnf/dnf.conf"):


### PR DESCRIPTION


setup.py line 50:

subprocess.Popen("wget https://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz", shell=True).wait()

but "https://pefile.googlecode.com/files/pefile-1.2.10-139.tar.gz" is a 404

this patch just downloads the pefile master.zip from github (https://github.com/erocarrera/pefile), and unzips it, instead of trying to download the tarball and untar-ing it