### PR TITLE
Fix a directory traversal bug in the harvester

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -237,8 +237,8 @@ class SETHandler(BaseHTTPRequestHandler):
             #print('-' * 40)
             pass
 
-        counter = 0
-
+        webroot = os.path.abspath(os.path.join(setdir, 'web_clone'))
+        requested_file = os.path.abspath(os.path.join(webroot, self.path))
         # try block setup to catch transmission errors
         try:
 
@@ -252,10 +252,9 @@ class SETHandler(BaseHTTPRequestHandler):
                 # write out that we had a visit
                 visits.write("hit\n")
                 # visits.close()
-                counter = 1
 
             # used for index2
-            if self.path == "/index2.html":
+            elif self.path == "/index2.html":
                 self.send_response(200)
                 self.send_header('Content_type', 'text/html')
                 self.end_headers()
@@ -265,25 +264,23 @@ class SETHandler(BaseHTTPRequestHandler):
                 # write out that we had a visit
                 visits.write("hit\n")
                 # visits.close()
-                counter = 1
 
             else:
-                if os.path.isfile(setdir + "/web_clone/%s" % (self.path)):
+                if not requested_file.startswith(webroot + os.path.sep):
+                    print('directory traversal attempt detected from: ' + self.client_address[0])
+                    self.send_response(404)
+                    self.end_headers()
+
+                elif os.path.isfile(requested_file):
                     self.send_response(200)
                     self.end_headers()
-                    fileopen = open(setdir + "/web_clone/%s" %
-                                    (self.path), "rb")
+                    fileopen = open(requested_file, "rb")
                     for line in fileopen:
                         self.wfile.write(line)
 
-            # if the file wasn't found
-            if counter == 0:
-                if os.path.isfile(setdir + "/web_clone/%s" % (self.path)):
-                    fileopen = open(setdir + "/web_clone/%s" %
-                                    (self.path), "rb")
-                    for line in fileopen:
-                        self.wfile.write(line)
-                    fileopen.close()
+                else:
+                    self.send_response(404)
+                    self.end_headers()
 
         # handle errors, log them and pass through
         except Exception as e:


### PR DESCRIPTION
This PR fixes a directory traversal bug in the harvestor code. The bug is only present when the Python webserver is used instead of Apache. To reproduce the bug follow the steps:
  * Set the config option `APACHE_SERVER=OFF` to use the builtin Python webserver
  * Start set and answer the prompts in the following order:
    * ``1) Social-Engineering Attacks``
    * ``2) Website Attack Vectors``
    * ``3) Credential Harvester Attack Method``
    * ``1) Web Templates``
    * Your IP address for the POST back i.e. ``1.2.3.4``
    * ``2. Google``
  * Go to another terminal while the collector is running and run `echo "GET /../../../../../../etc/shadow HTTP/1.0" | ncat localhost 80` to get the shadow file

This addresses the issue by normalizing the request path and ensuring it's under the expected path in relation to setdir.

With the patch applied the same steps can be repeated, however a warning message will be printed and the request will be responded to with a 404 response.