### PR TITLE
added anti-blocking inline images in "Mass Mailer Attack"

### DIFF
--- a/src/phishing/smtp/client/smtp_web.py
+++ b/src/phishing/smtp/client/smtp_web.py
@@ -212,6 +212,17 @@ if option1 != "99":
         if not os.path.isfile(file_format):
             file_format = ""
 
+    inline_files = []
+    while True:
+        yesno = raw_input("Do you want to attach an inline file - [y/n]: ")
+        if yesno.lower() == "y" or yesno.lower() == "yes":
+            inline_file = raw_input(
+                "Enter the path to the inline file you want to attach: ")
+            if os.path.isfile(inline_file):
+                inline_files.append( inline_file )
+        else:
+            break
+
     subject = input(setprompt(["1"], "Email subject"))
     try:
         html_flag = input(
@@ -315,8 +326,18 @@ def mail(to, subject, prioflag1, prioflag2, text):
         fileMsg.set_payload(file(file_format).read())
         email.encoders.encode_base64(fileMsg)
         fileMsg.add_header(
-            'Content-Disposition', 'attachment;filename=%s' % (file_format))
+            'Content-Disposition', 'attachment; filename="%s"' % os.path.basename(file_format) )
         msg.attach(fileMsg)
+
+    for inline_file in inline_files:
+        if inline_file != "":
+            fileMsg = email.mime.base.MIMEBase('application', '')
+            fileMsg.set_payload(file(inline_file).read())
+            email.encoders.encode_base64(fileMsg)
+            fileMsg.add_header(
+                'Content-Disposition', 'inline; filename="%s"' % os.path.basename(inline_file) )
+            fileMsg.add_header( "Content-ID", "<%s>" % os.path.basename(inline_file) )
+            msg.attach(fileMsg)
 
     mailServer = smtplib.SMTP(smtp, port)
 


### PR DESCRIPTION
I noticed, that all images in emails has banned. For example:
```
<img src="http://external.resource/image.png">
or
<img src="data:image/gif;base64,aaaabbbbccccddddeeee=">
```
But if we send image as:
```
...
Content-ID: <image1.png>
...
```
We will can to include one in html like this:
```
...
<img src="cid:image1.png">
...
```
This approach won't block. And we will see all images in our email.
In my opinion, an image is main part of social injection.