### PR TITLE
Fix bug where files for Tabnabbing and Webjacking were not served.

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -248,7 +248,7 @@ class SETHandler(BaseHTTPRequestHandler):
             pass
 
         webroot = os.path.abspath(os.path.join(userconfigpath, 'web_clone'))
-        requested_file = os.path.abspath(os.path.join(webroot, self.path))
+        requested_file = os.path.abspath(os.path.join(webroot, os.path.relpath(self.path, '/')))
         # try block setup to catch transmission errors
         try:
 
@@ -276,12 +276,7 @@ class SETHandler(BaseHTTPRequestHandler):
                 # visits.close()
 
             else:
-                if not requested_file.startswith(webroot + os.path.sep):
-                    print('directory traversal attempt detected from: ' + self.client_address[0])
-                    self.send_response(404)
-                    self.end_headers()
-
-                elif os.path.isfile(requested_file):
+                if os.path.isfile(requested_file):
                     self.send_response(200)
                     self.end_headers()
                     fileopen = open(requested_file, "rb")


### PR DESCRIPTION
This commit fixes a bug in the credential harvester Web attack
method that prevented these attacks from being successful.
Specifically, files needed for these attacks (e.g., `source.js`) in
the Web server's document root (`web_clone` folder) were treated as
though they were path traversal attacks, resulting an HTTP 404 sent
back to the (victim) browser; these attacks would fail.

In fact, files requested via URLs such as `/source.js` are valid
paths, but since they were not explicitly checked for in the same way
that the `index.html` and `index2.html` files were, these helper files
were not being served.

This fix improves URL handling by using Python's `os.path.relpath()`
method to ensure that all requested URLs are treated as relative to
the Web server's document root (`webroot` variable). This also
reliably prevents path traversal attacks because the
`requested_file` variable is always prepended with the Web root after
path calculations (normalizing `../` sequences, etcetera) have been
performed. As a result, the explicit check for the path traversal
detection is no longer needed; such requests will always error 404.