### PR TITLE
python3 compatibility fix regarding cStringIO

### DIFF
--- a/src/core/patched/socket.py
+++ b/src/core/patched/socket.py
@@ -84,7 +84,7 @@ import os, sys, warnings
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from io import StringIO
 
 try:
     import errno

--- a/src/phishing/smtp/client/smtp_web.py
+++ b/src/phishing/smtp/client/smtp_web.py
@@ -12,7 +12,7 @@ import base64
 # fix for python2 to 3 compatibility
 try:
     from cStringIO import StringIO
-except NameError:
+except ImportError:
     from io import StringIO
 import email
 import email.encoders


### PR DESCRIPTION
Using Python 3, and getting into Social-Engineering Attacks ->
Mass Mailer Attack, SET throws an error:

Something went wrong, printing the error: No module named 'cStringIO'

This fixes it, the change to socket.py fixes the module name,
and the change to smtp_web fixes the exception name.