### PR TITLE
Fix py3 incompatibility with regard to email module

### DIFF
--- a/src/phishing/smtp/client/smtp_web.py
+++ b/src/phishing/smtp/client/smtp_web.py
@@ -18,13 +18,28 @@ import email
 import email.encoders
 import email.mime.text
 import email.mime.base
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEBase import MIMEBase
-from email.MIMEText import MIMEText
+try:
+    from email.MIMEMultipart import MIMEMultipart
+except:
+    from email.mime.multipart import MIMEMultipart
+try:
+    from email.MIMEBase import MIMEBase
+except:
+    from email.mime.base import MIMEBase
+try:
+    from email.MIMEText import MIMEText
+except:
+    from email.mime.text import MIMEText
 from email.header import Header
 from email.generator import Generator
-from email import Charset
-from email import Encoders
+try:
+    from email import Charset
+except:
+    from email import charset as Charset
+try:
+    from email import Encoders
+except:
+    from email import encoders as Encoders
 
 Charset.add_charset('utf-8', Charset.BASE64, Charset.BASE64, 'utf-8')
 


### PR DESCRIPTION
Getting into Social-Engineering Attacks -> Mass Mailer Attack,
errors are thrown regarding the import of email modules.

This needs the fix in PR #648