### PR TITLE
Fixes #651, fixes #660: Pin pymssql requirement to existing version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ impacket
 # Generate QR Codes
 qrcode
 pillow
-pymssql
+# The pymssql project has been discontinued.
+pymssql<3.0


### PR DESCRIPTION
See also pymssql/pymssql#668 which describes the discontinuance of the
pymssql project.

This commit addresses the issue by simplistically pinning the dependency
on pymssql to an existing version.