### PR TITLE
Fixes #686: Starting SSL server causes import error.

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -21,6 +21,7 @@ try:
 
 except ImportError:
     from socketserver import *
+    import socketserver
 
 import threading
 import datetime
@@ -548,7 +549,10 @@ def run():
 class SecureHTTPServer(HTTPServer):
 
     def __init__(self, server_address, HandlerClass):
-        SocketServer.BaseServer.__init__(self, server_address, HandlerClass)
+        try:
+            SocketServer.BaseServer.__init__(self, server_address, HandlerClass)
+        except NameError:
+            socketserver.BaseServer.__init__(self, server_address, HandlerClass)
         # SSLv2 and SSLv3 supported
         ctx = SSL.Context(SSL.SSLv23_METHOD)
         # pem files defined before


### PR DESCRIPTION
This resolves the first issue in a line of several preventing the
SSL-capable server from spinning up correctly as described in the
referenced issue number. The cause is simply a missing import when
`setoolkit` is run under Python 3.

Please note that there are additional issues preventing SET from returning
HTTPS responses when `WEBATTACK_SSL` and `SELF_SIGNED_CERT` are
both to `ON` in the `/etc/setoolkit/set.config` file; this is just the first of those
and the only one I have time to debug this evening.