### PR TITLE
Make `seautomate` functional with Python 3.

### DIFF
--- a/seautomate
+++ b/seautomate
@@ -6,6 +6,7 @@ import os
 import time
 import subprocess
 import re
+from distutils.spawn import find_executable
 
 # Py2/3 compatibility
 # Python3 renamed raw_input to input
@@ -19,7 +20,6 @@ try:
 
 except NameError:
     from importlib import reload
-
 
 # check where we are and load default directory
 if os.path.isdir("/usr/share/setoolkit"):
@@ -73,7 +73,8 @@ password = False
 if os.path.isfile(filename):
     try:
         print("[*] Spawning SET in a threaded process...")
-        child = pexpect.spawn("python setoolkit")
+        cmd = find_executable('python3') or find_executable('python')
+        child = pexpect.spawn("{} setoolkit".format(cmd))
         child.expect("99\) Exit the Social-Engineer Toolkit")
         with open(filename) as fileopen:
             for line in fileopen:


### PR DESCRIPTION
Per Debian policy, Python versions 3 and greater must be called from the
`python3` executable, not the `python` executable. This means
Debian-based systems with Python 3 installed but not Python 2 will fail
to launch SET through `seautomate` because the `python` executable is
hard-coded into the call to `pexpect.spawn()`.

This commit uses the standard library's
`distutils.spawn.find_executable()` method to locate the correct path to
`python3` or, failing that, the correct path to the `python` executable
and uses the result of that call as the first command line word with
which to invoke `setoolkit`.

The `distutils.spawn.find_executable()` method is available at that
exact name in both Python 2 and 3, so this should be portable across all
Python versions.

Note that the shebang line references `python`, and so Python 3-only
systems such as newer Debian-based builds may need to invoke
`seautomate` using an explicit interpreter for it to work:

```sh
sudo python3 ./seautomate /path/to/script/file.txt
```