### PR TITLE
First pass at surviving certain TLS connection issues. See #696.

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -566,7 +566,10 @@ class SecureHTTPServer(HTTPServer):
         self.server_activate()
 
     def shutdown_request(self, request): 
-        request.shutdown()
+        try:
+            pass
+        except KeyboardInterrupt:
+            request.shutdown()
 
 
 def ssl_server(HandlerClass=SETHandler, ServerClass=SecureHTTPServer):

--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -385,8 +385,8 @@ def run():
             server.serve_forever()
         # handle keyboard interrupts
         except KeyboardInterrupt:
+            server.socket.close()
             generate_reports()
-            httpd.socket.close()
 
         # handle the rest
         except Exception as e:
@@ -412,28 +412,14 @@ def run():
                 print_status("Harvester is ready, have victim browse to your site.")
                 if apache_check == False:
                     try:
-
                         try:
                             server = ThreadedHTTPServer(
                                 ('', int(web_port)), SETHandler)
                             server.serve_forever()
-
                         # handle keyboard interrupts
                         except KeyboardInterrupt:
-                            os.chdir(homepath)
-                        try:
-                            visits.close()
-                            bites.close()
-
-                        except:
-                            pass
-                        if attack_vector != 'multiattack':
-                            sys.path.append("src/harvester")
-                            from . import report_generator
-                        if attack_vector != 'multiattack':
-                            return_continue()
-                        os.chdir(homepath)
-                        httpd.socket.close()
+                            generate_reports()
+                        server.socket.close()
                     except Exception:
                         apache_counter = 0
 
@@ -561,9 +547,9 @@ def ssl_server(HandlerClass=SETHandler, ServerClass=SecureHTTPServer):
         # bind to all interfaces on 443
         server_address = ('', 443)  # (address, port)
         # setup the httpd server
-        httpd = ServerClass(server_address, HandlerClass)
+        server = ServerClass(server_address, HandlerClass)
         # serve the httpd server until exit
-        httpd.serve_forever()
+        server.serve_forever()
     except Exception as e: 
         print_error("Something went wrong.. Printing error: " + str(e))
     except KeyboardInterrupt:

--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -381,27 +381,11 @@ def run():
     # check if we are not running apache mode
     if apache_check == False:
         try:
-
             server = ThreadedHTTPServer(('', int(web_port)), SETHandler)
             server.serve_forever()
-
         # handle keyboard interrupts
         except KeyboardInterrupt:
-            os.chdir(homepath)
-            try:
-                visits.close()
-                bites.close()
-
-            except:
-                pass
-            if attack_vector != 'multiattack':
-                try:
-                    module_reload(src.webattack.harvester.report_generator)
-                except:
-                    import src.webattack.harvester.report_generator
-            if attack_vector != 'multiattack':
-                return_continue()
-            os.chdir(homepath)
+            generate_reports()
             httpd.socket.close()
 
         # handle the rest
@@ -568,12 +552,11 @@ class SecureHTTPServer(HTTPServer):
     def shutdown_request(self, request): 
         try:
             pass
-        except KeyboardInterrupt:
+        except Exception as e:
             request.shutdown()
 
 
 def ssl_server(HandlerClass=SETHandler, ServerClass=SecureHTTPServer):
-
     try:
         # bind to all interfaces on 443
         server_address = ('', 443)  # (address, port)
@@ -583,6 +566,23 @@ def ssl_server(HandlerClass=SETHandler, ServerClass=SecureHTTPServer):
         httpd.serve_forever()
     except Exception as e: 
         print_error("Something went wrong.. Printing error: " + str(e))
+    except KeyboardInterrupt:
+        generate_reports()
+
+def generate_reports():
+    os.chdir(homepath)
+    try:
+        visits.close()
+        bites.close()
+    except:
+        pass
+    if attack_vector != 'multiattack':
+        try:
+            module_reload(src.webattack.harvester.report_generator)
+        except:
+            import src.webattack.harvester.report_generator
+    if attack_vector != 'multiattack':
+        return_continue()
 
 if track_email == True:
     webattack_email = True


### PR DESCRIPTION
This is probably a kludge because I am not super familiar with TLS
socket programming or SET generally, but it achieves the result, which
is not to shutdown the (HTTPS) socket server when a TLS client responds
to a TLS Server Hello message with a fatal Alert message.

One example of a client that does this is recent Firefox. What this
means is that if you run SET with `WEBATTACK_SSL=ON` and
`SELF_SIGNED_CERT=ON`, your victim can turn off your HTTPS server simply
by navigating to your attack page.

This is caused by the underlying OpenSSL library raising an error that
`pyopenssl`, in turn, `raise`s through the socket server libraries.
Ultimately, it bubbles up to the `harvester` module through its
`shutdown_request` method, called by the underlying socket server's
`_handle_request_noblock` method. See the backtrace printed in the
comments of Pull Request #696 for a complete example.

The bottom line is that this unhandled exception ultimately causes the
HTTPS server to die before it gets a chance to be useful. Since I assume
that SET doesn't particularly care what certificate validation alerts the
client is sending us, this patch addresses the issue by ignoring every
raised exception from the underlying libraries except for a
`KeyboardInterrupt` so that the SET user can cause a server shutdown
themselves, with the expected `C-c` interrupt signal.

There is probably a more graceful way to handle this, though? Also, note
that this only fixes the HTTPS issues for Python 3. Python 2 exhibits a
different error altogether.