### PR TITLE
Revive SET's built-in DNS responder under Python 3

### DIFF
--- a/setoolkit
+++ b/setoolkit
@@ -127,7 +127,8 @@ if operating_system == "posix":
 dns = core.check_config("DNS_SERVER=")
 if dns.lower() == "on":
     import src.core.minifakedns
-    src.core.minifakedns.start_dns_server()
+    from src.core.setcore import detect_public_ip
+    src.core.minifakedns.start_dns_server(detect_public_ip())
 
 # remove old files
 for root, dirs, files in os.walk(core.userconfigpath):

--- a/setoolkit
+++ b/setoolkit
@@ -126,7 +126,8 @@ if operating_system == "posix":
 
 dns = core.check_config("DNS_SERVER=")
 if dns.lower() == "on":
-    core.start_dns()
+    import src.core.minifakedns
+    src.core.minifakedns.start_dns_server()
 
 # remove old files
 for root, dirs, files in os.walk(core.userconfigpath):
@@ -153,7 +154,6 @@ if not os.path.isfile("/etc/setoolkit/set_config.py"):
     update_config()
 
 define_version = core.get_version()
-core.cleanup_routine()
 
 # create the set.options routine
 with open(os.path.join(core.userconfigpath, "set.options"), "w") as filewrite:

--- a/src/core/minifakedns.py
+++ b/src/core/minifakedns.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+"""
+SET core PyFakeMiniDNS server implementation.
+
+Slightly modified implementation of Francisco Santos's PyfakeminiDNS
+script designed to run as a thread and handle various additional
+system configuration tasks, if necessary in the running environment,
+along with a few implementation considerations specifically for SET.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+
+# We need this module variable so the helper functions can be called
+# from outside of this module, e.g., during SET startup and cleanup.
+dns_server_thread = None
+
+def start_dns_server():
+    """
+    Helper function, intended to be called from other modules.
+    """
+    global dns_server_thread
+    dns_server_thread = MiniFakeDNS(kwargs={'port': 53, 'ip': '1.2.3.4'})
+    dns_server_thread.start()
+
+def stop_dns_server():
+    """
+    Helper function, intended to be called from other modules.
+    """
+    dns_server_thread.stop()
+    dns_server_thread.join()
+    dns_server_thread.cleanup()
+
+class DNSQuery:
+    """
+     A DNS query (that can be parsed as binary data).
+
+     See original for reference, but note there have been changes:
+     https://code.activestate.com/recipes/491264-mini-fake-dns-server/
+
+    """
+
+    def __init__(self, data):
+        self.data = data
+        self.dominio = ''
+
+        tipo = (ord(data[2]) >> 3) & 15   # Opcode bits
+        if tipo == 0:                     # Standard query
+            ini = 12
+            lon = ord(data[ini])
+            while lon != 0:
+                self.dominio += data[ini + 1:ini + lon + 1] + '.'
+                ini += lon + 1
+                lon = ord(data[ini])
+
+    def respuesta(self, ip):
+        packet = ''
+        if self.dominio:
+            packet += self.data[:2] + "\x81\x80"
+            packet += self.data[4:6] + self.data[4:6] + '\x00\x00\x00\x00' # Questions and Answers Counts
+            packet += self.data[12:]                                       # Original Domain Name Question
+            packet += '\xc0\x0c'                                           # Pointer to domain name
+            packet += '\x00\x01\x00\x01\x00\x00\x00\x3c\x00\x04' # Response type, ttl and resource data length -> 4 bytes
+            packet += str.join('', [chr(int(x)) for x in ip.split('.')])   # 4bytes of IP
+        return packet
+
+class MiniFakeDNS(threading.Thread):
+    """
+    The MiniFakeDNS server, written to be run as a Python Thread.
+    """
+    def __init__(self, group=None, target=None, name=None,
+                       args=(), kwargs=None):
+        super(MiniFakeDNS, self).__init__(
+                group=group, target=target, name=name)
+        self.args = args
+        self.kwargs = kwargs
+
+        # The IPs address we will respond with.
+        self.ip = kwargs['ip']
+
+        # The port number we will attempt to bind to. Default is 53.
+        self.port = kwargs['port']
+
+        # Remember which configuration we usurped, if any. Used to cleanup.
+        self.cede_configuration = None
+
+        # A flag to indicate that the thread should exit.
+        self.stop_flag = False
+
+    def run(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udps:
+            udps.setblocking(False)
+            try:
+                udps.bind(('', self.port))
+            except OSError as e:
+                if 'Address already in use' == e.strerror and os.path.exists('/etc/resolv.conf'):
+                    # We can't listen on port 53 because something else got
+                    # there before we did. It's probably systemd-resolved's
+                    # DNS stub resolver, but since we are probably running as
+                    # the `root` user, we can fix this ourselves.
+                    if 'stub-resolv.conf' in os.path.realpath('/etc/resolv.conf'):
+                        self.usurp_systemd_resolved()
+                        self.cede_configuration = self.cede_to_systemd_resolved
+                    # Try binding again, now that the port might be available.
+                    udps.bind(('', self.port))
+            while not self.stop_flag:
+                try:
+                    data, addr = udps.recvfrom(1024)
+                    p = DNSQuery(data)
+                    udps.sendto(p.respuesta(self.ip), addr)
+                except BlockingIOError:
+                    pass
+            print("Exiting the DNS Server..")
+        sys.exit()
+
+    def cleanup(self):
+        if self.cede_configuration is not None:
+            self.cede_configuration()
+
+    def stop(self):
+        """
+        Signals to the DNS server thread to stop.
+        """
+        self.stop_flag = True
+
+    def usurp_systemd_resolved(self):
+        """
+        Helper function to get systemd-resolved out of the way when it
+        is listening on 127.0.0.1:53 and we are trying to run SET's
+        own DNS server.
+        """
+        try:
+            os.mkdir('/etc/systemd/resolved.conf.d')
+        except (OSError, FileExistsError):
+            pass
+        with open('/etc/systemd/resolved.conf.d/99-setoolkit-dns.conf', 'w') as f:
+            f.write("[Resolve]\nDNS=9.9.9.9\nDNSStubListener=no")
+        os.rename('/etc/resolv.conf', '/etc/resolv.conf.original')
+        os.symlink('/run/systemd/resolve/resolv.conf', '/etc/resolv.conf')
+        subprocess.call(['systemctl', 'restart', 'systemd-resolved.service'])
+
+    def cede_to_systemd_resolved(self):
+        """
+        Helper function to cede system configuration back to systemd-resolved
+        after we have usurped control over DNS configuration away from it.
+        """
+        os.remove('/etc/systemd/resolved.conf.d/99-setoolkit-dns.conf')
+        os.remove('/etc/resolv.conf')
+        os.rename('/etc/resolv.conf.original', '/etc/resolv.conf')
+        subprocess.call(['systemctl', 'restart', 'systemd-resolved.service'])
+

--- a/src/core/minifakedns.py
+++ b/src/core/minifakedns.py
@@ -96,15 +96,15 @@ class DNSQuery:
         #    000 0 0000
         #
         # To test for this reliably, we do a bitwise AND with a value
-        # of decimal 15, which is 1111 in binary, exactly four bits:
+        # of decimal 31, which is 11111 in binary, exactly five bits:
         #
         #      00000000  (Remember, 0 AND 1 equals 0.)
-        #  AND 00001111
+        #  AND 00011111
         #  ------------
         #      00000000 = decimal 0
         #
         # In one line of Python code, we get the following:
-        kind = (flags[0] >> 3) & 15 # Opcode is in bits 4, 5, 6, and 7 of first byte.
+        kind = (flags[0] >> 3) & 31 # Opcode is in bits 4, 5, 6, and 7 of first byte.
                                     # QR bit is 8th bit, but it should be 0.
                                     # And now, we test to see if the result
         if 0 == kind:               # was a standard query.

--- a/src/core/set.py
+++ b/src/core/set.py
@@ -345,10 +345,7 @@ this is how networking works.
 """)
 
                                     try:
-                                        rhost = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                                        rhost.connect(('google.com', 0))
-                                        rhost.settimeout(2)
-                                        revipaddr = rhost.getsockname()[0]
+                                        revipaddr = detect_public_ip()
                                         ipaddr = raw_input(setprompt(["2"], "IP address for the POST back in Harvester/Tabnabbing [" + revipaddr + "]"))
                                         if ipaddr == "": ipaddr=revipaddr
                                     except Exception:

--- a/src/core/setcore.py
+++ b/src/core/setcore.py
@@ -304,7 +304,19 @@ class create_menu:
         return
 
 
+def detect_public_ip():
+    """
+    Helper function to auto-detect our public IP(v4) address.
+    """
+    rhost = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rhost.connect(('google.com', 0))
+    rhost.settimeout(2)
+    return rhost.getsockname()[0]
+
 def validate_ip(address):
+    """
+    Validates that a given string is an IPv4 dotted quad.
+    """
     try:
         if socket.inet_aton(address):
             if len(address.split('.')) == 4:
@@ -429,10 +441,7 @@ def meta_database():
 #
 def grab_ipaddress():
     try:
-        rhost = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        rhost.connect(('google.com', 0))
-        rhost.settimeout(2)
-        revipaddr = rhost.getsockname()[0]
+        revipaddr = detect_public_ip()
         rhost = raw_input(setprompt("0", "IP address or URL (www.ex.com) for the payload listener (LHOST) [" + revipaddr + "]"))
         if rhost == "": rhost = revipaddr
 


### PR DESCRIPTION
This pull request revives the built-in DNS server so that it is functional again, at least when run under Python 3. Currently, there are numerous problems that prevent the `DNS_SERVER=ON` configuration from being effective. These include:

* [x] On *nix systems running systemd, the `systemd-resolved` stub resolver is already bound to port 53, causing an "Address already in use" error (an `OSError` exception) when SET starts.
* [x] The DNS server code never shut down cleanly because it was written to exit only on a `KeyboardInterrupt`. Since it was running as a thread, however, and since SET swallows keyboard interrupt exceptions in a lot of other places, this signal never reached the DNS thread. [Signals and threads are a bit dicey in Python anyway](https://docs.python.org/3/library/signal.html#signals-and-threads). A different design pattern (sentinel value?) is needed.
* [x] When SET receives a DNS query, an unhandled exception is raised that causes the DNS query to go unanswered. The exceptions are different on Python 2 and Python 3. For example, when SET is invoked by Python 3:
    ```
    Unhandled exception in thread started by <function dns at 0x7fcf27decea0>
    Traceback (most recent call last):
      File "/home/vagrant/set/src/core/setcore.py", line 1790, in dns
        p = DNSQuery(data)
      File "/home/vagrant/set/src/core/setcore.py", line 1714, in __init__
        tipo = (ord(data[2]) >> 3) & 15   # Opcode bits
    TypeError: ord() expected string of length 1, but int found
    ```

This pull request is safe for both Python 2 and Python 3. However, when run with `DNS_SERVER=ON` under Python 2, a non-fatal exception is thrown that prevents the built-in DNS server from starting up successfuly:

```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/home/vagrant/set/src/core/minifakedns.py", line 184, in run
    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udps:
AttributeError: __exit__
```

When run on a system employing `systemd-resolved` as its DNS resolver bound to port 53 on the loopback address, the above exception could leave the system in a misconfigured state. Given that Python 2 has been officially EOL'ed since January 1, 2020, and that this issue only presents when `DNS_SERVER=ON` is present in SET's config file, I decided not to bother guarding against that. Please let me know if that's a blocker.