### PR TITLE
Fix utf-8 codec error (2/2)

### DIFF
--- a/src/webattack/harvester/scraper.py
+++ b/src/webattack/harvester/scraper.py
@@ -59,7 +59,7 @@ if apache_mode == "on":
     apache_rewrite = "post.php"
 
 # start the scraping process
-fileopen = open(userconfigpath + "web_clone/%s" % (site), "r").readlines()
+fileopen = open(userconfigpath + "web_clone/%s" % (site), "r", encoding='utf-8', errors='ignore').readlines()
 filewrite = open(userconfigpath + "web_clone/index.html.new", "w")
 for line in fileopen:
 


### PR DESCRIPTION
This is necessary in order to fix the error with the site cloner:
"Something went wrong, printing the error: 'utf-8' codec can't decode byte 0xc2 in position 387: invalid continuation byte"
The same error is also contained in src/webattack/web_clone/cloner.py file