### PR TITLE
Fix a bytes-like object is required

### DIFF
--- a/src/core/webserver.py
+++ b/src/core/webserver.py
@@ -52,12 +52,12 @@ class StoppableHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
             else:
                 return self.list_directory(path)
         ctype = self.guess_type(path)
-        if ctype.startswith('text/'):
-            mode = 'r'
-        else:
-            mode = 'rb'
+        #if ctype.startswith('text/'):
+        #    mode = 'rb'
+        #else:
+        #    mode = 'rb'
         try:
-            f = open(path, mode)
+            f = open(path, "rb")
         except IOError:
             self.send_error(404, "File not found")
             return None


### PR DESCRIPTION
Fix the exception when you start http server in option Website Attack Vectors. In python3, 'str' type converted to "bytes" type, so when you start http server , you get error exception: "a bytes-like object is required, not 'str' when setting filename"