### PR TITLE
Fix missing space in setprompt

### DIFF
--- a/src/core/setcore.py
+++ b/src/core/setcore.py
@@ -194,7 +194,7 @@ def setprompt(category, text):
                 prompt += ":" + bcolors.UNDERL + \
                     bcolors.DARKCYAN + level + bcolors.ENDC
             promptstring = str(prompt)
-            promptstring = promptstring + "> " + text + ":"
+            promptstring = promptstring + "> " + text + ": "
             return promptstring
 
 


### PR DESCRIPTION
Resulted in prompts without a trailing space e.g.
![](https://i.binclub.dev/kcltsjjp.png)