### PR TITLE
non needed library after cgi.escape was changed to html.escape

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 import os
 import re
-import cgi
 import posixpath
 import mimetypes
 import urllib.parse


### PR DESCRIPTION
Sorry if I did this wrong, first time doing this.