### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:latest
 
 # Update sources and install git
-RUN apt update -y && apt install git -y && apt install python3-pip -y 
+RUN apt-get update -y && apt-get install -y git python3-pip
 
 #Git configuration
 RUN git config --global user.name "YOUR NAME HERE" \
     && git config --global user.email "YOUR EMAIL HERE"
 
 # Clone SETOOLKIT
-RUN git clone https://github.com/trustedsec/social-engineer-toolkit.git
+RUN git clone --depth=1 https://github.com/trustedsec/social-engineer-toolkit.git
 
 # Change Working Directory
 WORKDIR /social-engineer-toolkit


### PR DESCRIPTION
Fixes #910 
- Use apt-get instead of apt, and install all packages at once
- Do a shallow clone. Saves bandwidth and time.