### PR TITLE
Allow import cgi on older python versions

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -4,7 +4,11 @@ import sys
 import html
 import os
 import re
-import cgi
+
+try:
+    from cgi import escape
+except ImportError:
+    from html import escape
 
 # need for python2 -> 3
 try:
@@ -332,7 +336,7 @@ class SETHandler(BaseHTTPRequestHandler):
                 else:
                     line = ""
                 counter = 1
-            filewrite.write(html.escape("PARAM: " + line + "\n"))
+            filewrite.write(escape("PARAM: " + line + "\n"))
             filewrite2.write(line + "\n")
             # if a counter hits at 0 then print this line
             if counter == 0:


### PR DESCRIPTION
This PR allows older python version to still function.
It should fix issues:
#827 
#820 
#763 
#754 
#752 
#733 
#730 
#720 
#715 