### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/core/webserver.py
+++ b/src/core/webserver.py
@@ -19,7 +19,7 @@ class StoppableHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
         self.server.stop = True
 
     def do_POST(self):
-        # We could also process paremeters here using something like below.
+        # We could also process parameters here using something like below.
         self.do_GET()
 
     def send_head(self):

--- a/src/payloads/set_payloads/uac_bypass/source/TIOR/TIOR.cpp
+++ b/src/payloads/set_payloads/uac_bypass/source/TIOR/TIOR.cpp
@@ -10,7 +10,7 @@
 //
 //	This application is used for redirection data from the console to the pipes, 
 //	not useng pipes at the other side.
-//	It is caused by some differences when using some other proceses which
+//	It is caused by some differences when using some other processes which
 //	also redirect data. Main reason is differences in ReadConsole and ReadFile
 //	methods.
 //	Using this redirector app, child process will never know that his parent redirects it's IO.

--- a/src/teensy/ino_gen.py
+++ b/src/teensy/ino_gen.py
@@ -108,7 +108,7 @@ with open(ino_output_filename,'wb') as ino_output_file:                     # Op
                     print('-----Formatting shellcode for ino file-----')     # Progress notification to the user.
                     ino_output_file.writelines( teensy_gen.ino_print_gen(payload_shellcode[0:34] ) + '\n' )  # format first line as shorter than rest.
 
-                    while (start_pos <= length):                            # format the remaning lines of shellcode.
+                    while (start_pos <= length):                            # format the remaining lines of shellcode.
                         end_pos = start_pos + width                         # Set the position of end_pos.
                         if (end_pos >= (length - 3)):                       # Check if end position is greater than the length of the shellcode.
                             end_pos = length                                 # set the end position for the last line.


### PR DESCRIPTION
There are small typos in:
- src/core/webserver.py
- src/payloads/set_payloads/uac_bypass/source/TIOR/TIOR.cpp
- src/teensy/ino_gen.py

Fixes:
- Should read `remaining` rather than `remaning`.
- Should read `processes` rather than `proceses`.
- Should read `parameters` rather than `paremeters`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md