### PR TITLE
Socket Server Undefined Fix - SSL Credential Harvester

### DIFF
--- a/src/webattack/harvester/harvester.py
+++ b/src/webattack/harvester/harvester.py
@@ -22,10 +22,11 @@ import socket
 # needed for python2 -> 3
 try:
     from SocketServer import *
-    import SocketServer
+    import SocketServer as ss
 
 except ImportError:
     from socketserver import *
+    import socketserver as ss
 
 import threading
 import datetime
@@ -553,7 +554,7 @@ def run():
 class SecureHTTPServer(HTTPServer):
 
     def __init__(self, server_address, HandlerClass):
-        SocketServer.BaseServer.__init__(self, server_address, HandlerClass)
+        ss.BaseServer.__init__(self, server_address, HandlerClass)
         # SSLv2 and SSLv3 supported
         ctx = SSL.Context(SSL.SSLv23_METHOD)
         # pem files defined before


### PR DESCRIPTION
When trying to run the credential harvester using SSL with either SET generated or user own pem files, SET throws the error: "[!] Something went wrong .. Printing error:  name 'SocketServer' is not defined"

SET was running on the linuxserver/kali-linux version-ff17a2a9 docker image with python 3.13.2 installed

Pull request changes harvester.py and specifies aliases for SocketServer to prevent undefined references.