### PR TITLE
Fix typo: occured -> occurred in error messages

### DIFF
--- a/src/core/arp_cache/arp.py
+++ b/src/core/arp_cache/arp.py
@@ -113,7 +113,7 @@ if ettercapchoice == 'y':
         except Exception as error:
             os.chdir(cwd)
             # log(error)
-            print_error("ERROR:An error has occured:")
+            print_error("ERROR:An error has occurred:")
             print("ERROR:" + str(error))
 
 # if we are using dsniff

--- a/src/core/setcore.py
+++ b/src/core/setcore.py
@@ -1328,7 +1328,7 @@ def custom_template():
         print("\n")
         filewrite.close()
     except Exception as e:
-        print_error("ERROR:An error occured:")
+        print_error("ERROR:An error occurred:")
         print(bcolors.RED + "ERROR:" + str(e) + bcolors.ENDC)
 
 

--- a/src/payloads/set_payloads/listener.py
+++ b/src/payloads/set_payloads/listener.py
@@ -216,7 +216,7 @@ def start_listener():
         # handle exceptions
         except Exception as e:
             print_warning(
-                "An exception occured. Handling it and keeping session alive. Error: " + str(e))
+                "An exception occurred. Handling it and keeping session alive. Error: " + str(e))
             pass
 
     # decrypt received packets
@@ -235,7 +235,7 @@ def start_listener():
         # handle exceptions
         except Exception as e:
             print_warning(
-                "An exception occured. Handling it and keeping session alive. Error: " + str(e))
+                "An exception occurred. Handling it and keeping session alive. Error: " + str(e))
             pass
 
     # handle tab completion here for set interactive menu

--- a/src/phishing/smtp/client/custom_template.py
+++ b/src/phishing/smtp/client/custom_template.py
@@ -27,4 +27,4 @@ try:
     print("\n")
     filewrite.close()
 except Exception as e:
-    print("   An error occured, printing error message: " + str(e))
+    print("   An error occurred, printing error message: " + str(e))


### PR DESCRIPTION
Fix 4 occurrences of `occured` → `occurred` in user-facing error messages across 4 Python files:
- `src/phishing/smtp/client/custom_template.py` (line 30)
- `src/core/arp_cache/arp.py` (line 116)
- `src/core/setcore.py` (line 1331)
- `src/payloads/set_payloads/listener.py` (lines 219, 238)

All instances are print/error messages shown to users when exceptions occur.